### PR TITLE
Type args needn't be top-level declarations

### DIFF
--- a/src/fsharp/env.fs
+++ b/src/fsharp/env.fs
@@ -556,8 +556,6 @@ let mkTcGlobals (compilingFslib,sysCcu,ilg,fslibCcu,directoryToResolveRelativePa
   let varc = NewRigidTypar "c" envRange
   let vard = NewRigidTypar "d" envRange
   let vare = NewRigidTypar "e" envRange
-  let varf = NewRigidTypar "f" envRange
-  let varg = NewRigidTypar "g" envRange
 
   let varaTy = mkTyparTy vara 
   let varbTy = mkTyparTy varb 


### PR DESCRIPTION
These declarations interact with global mutable state when initialized. They are only used by the `mkTcGlobals` method so there is no reason why they should be top-level.
