### PR TITLE
Generate API docs

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -20,10 +20,12 @@ let info =
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../packages/FSharp.Formatting.2.2.11-beta/lib/net40"
-#I "../../packages/RazorEngine.3.3.0/lib/net40/"
+#I "../../packages/FSharp.Formatting.2.3.4-beta/lib/net40"
+#I "../../packages/RazorEngine.3.3.0/lib/net40"
 #r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
+#I "../../packages/FSharp.Compiler.Service.0.0.11-alpha/lib/net40"
 #r "../../packages/FAKE/tools/FakeLib.dll"
+#r "FSharp.Compiler.Service.dll"
 #r "RazorEngine.dll"
 #r "FSharp.Literate.dll"
 #r "FSharp.CodeFormat.dll"
@@ -48,7 +50,7 @@ let content     = __SOURCE_DIRECTORY__ @@ "../content"
 let output      = __SOURCE_DIRECTORY__ @@ "../output"
 let files       = __SOURCE_DIRECTORY__ @@ "../files"
 let templates   = __SOURCE_DIRECTORY__ @@ "templates"
-let formatting  = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.2.11-beta/"
+let formatting  = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.3.4-beta/"
 let docTemplate = formatting @@ "templates/docpage.cshtml"
 
 // Where to look for *.csproj templates (in this order)
@@ -69,7 +71,9 @@ let buildReference () =
   for lib in referenceBinaries do
     MetadataFormat.Generate
       ( bin @@ lib, output @@ "reference", layoutRoots, 
-        parameters = ("root", root)::info (* ,publicOnly=true *) )
+        parameters = ("root", root)::info,
+        sourceRepo = "https://github.com/fsharp/FSharp.Compiler.Service/tree/master/src",
+        sourceFolder = @"..\..\src", publicOnly=true )
 
 // Build documentation from `fsx` and `md` files in `docs/content`
 let buildDocumentation () =

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -62,7 +62,8 @@
             <li><a href="@Root/filesystem.html">Virtualized file system</a></li>
 
             <li class="nav-header">Documentation</li>
-            <li><!-- <a href="@Root/reference/index.html">API Reference</a> (Preliminary) --> API Reference (Coming soon)</li>
+            <li><a href="@Root/reference/index.html">API Reference</a> (Preliminary)
+            </li>
           </ul>
         </div>
       </div>

--- a/src/fsharp/FSharp.Compiler.Service/packages.config
+++ b/src/fsharp/FSharp.Compiler.Service/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FSharp.Formatting" version="2.3.4-beta" targetFramework="net40" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
+  <package id="RazorEngine" version="3.3.0" targetFramework="net40" />
+  <package id="FSharp.Compiler.Service" version="0.0.11-alpha" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
FSharp.Formatting 2.3.4-beta finally is able to generate API docs for `FSharp.Compiler.Service`.

I adjusted the build script to generate API docs for public members and automatically create GitHub links to all functions and members.
It takes 200 seconds in my machine (not bad).

Documentation needs some love, but once the first version goes live; it is much easier to improve.
