### PR TITLE
Expose lexing functions for XMLDoc extension

### DIFF
--- a/src/fsharp/lexfilter.fs
+++ b/src/fsharp/lexfilter.fs
@@ -12,7 +12,7 @@
 
 /// LexFilter - process the token stream prior to parsing.
 /// Implements the offside rule and a copule of other lexical transformations.
-module internal Microsoft.FSharp.Compiler.Lexfilter
+module (*internal*) Microsoft.FSharp.Compiler.Lexfilter
 
 open Internal.Utilities
 open Internal.Utilities.Text.Lexing
@@ -2277,3 +2277,4 @@ type LexFilter (lightSyntaxStatus:LightSyntaxStatus, compilingFsLib, lexer, lexb
             | _ -> token
         loop()
 
+let token lexargs skip = Lexer.token lexargs skip

--- a/src/fsharp/lexhelp.fsi
+++ b/src/fsharp/lexhelp.fsi
@@ -47,7 +47,7 @@ val resetLexbufPos : string -> UnicodeLexing.Lexbuf -> unit
 val mkLexargs : 'a * string list * LightSyntaxStatus * LexResourceManager * LexerIfdefStack * ErrorLogger -> lexargs
 val reusingLexbufForParsing : UnicodeLexing.Lexbuf -> (unit -> 'a) -> 'a 
 
-val internal usingLexbufForParsing : UnicodeLexing.Lexbuf * string -> (UnicodeLexing.Lexbuf -> 'a) -> 'a
+val (*internal*) usingLexbufForParsing : UnicodeLexing.Lexbuf * string -> (UnicodeLexing.Lexbuf -> 'a) -> 'a
 val internal defaultStringFinisher : 'a -> 'b -> byte[] -> Parser.token
 val internal callStringFinisher : ('a -> 'b -> byte[] -> 'c) -> AbstractIL.Internal.ByteBuffer -> 'a -> 'b -> 'c
 val internal addUnicodeString : AbstractIL.Internal.ByteBuffer -> string -> unit
@@ -68,8 +68,8 @@ exception internal ReservedKeyword of string * Range.range
 exception internal IndentationProblem of string * Range.range
 
 module Keywords = 
-    val internal KeywordOrIdentifierToken : lexargs -> UnicodeLexing.Lexbuf -> string -> Parser.token
-    val internal IdentifierToken : lexargs -> UnicodeLexing.Lexbuf -> string -> Parser.token
+    val (*internal*) KeywordOrIdentifierToken : lexargs -> UnicodeLexing.Lexbuf -> string -> Parser.token
+    val (*internal*) IdentifierToken : lexargs -> UnicodeLexing.Lexbuf -> string -> Parser.token
     val (*internal*) QuoteIdentifierIfNeeded : string -> string
-    val mutable internal permitFsharpKeywords : bool 
+    val mutable (*internal*) permitFsharpKeywords : bool 
     val keywordNames : string list

--- a/src/fsharp/unilex.fs
+++ b/src/fsharp/unilex.fs
@@ -10,7 +10,7 @@
 // You must not remove this notice, or any other, from this software.
 //----------------------------------------------------------------------------
 
-module internal Microsoft.FSharp.Compiler.UnicodeLexing
+module (*internal*) Microsoft.FSharp.Compiler.UnicodeLexing
 
 //------------------------------------------------------------------
 // Functions for Unicode char-based lexing (new code).

--- a/src/fsharp/unilex.fsi
+++ b/src/fsharp/unilex.fsi
@@ -10,7 +10,7 @@
 // You must not remove this notice, or any other, from this software.
 //----------------------------------------------------------------------------
 
-module internal Microsoft.FSharp.Compiler.UnicodeLexing
+module (*internal*) Microsoft.FSharp.Compiler.UnicodeLexing
 
 open Microsoft.FSharp.Text
 open Internal.Utilities.Text.Lexing

--- a/src/utils/filename.fs
+++ b/src/utils/filename.fs
@@ -10,7 +10,7 @@
 //----------------------------------------------------------------------------
 
 
-module internal Internal.Utilities.Filename
+module (*internal*) Internal.Utilities.Filename
 
 open System.IO
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library 


### PR DESCRIPTION
I'm migrating F# XMLDoc extension to VS 2012 and VS 2013 as part of https://github.com/fsprojects/FSharpVSPowerTools.

Here are the minimal changes in order that F# XMLDoc can be migrated to use FSharp.Compiler.Service (see https://github.com/fsprojects/FSharpVSPowerTools/issues/4 for more details).

If this is merged, please publish a new version on NuGet. 
