### PR TITLE
Make FSharpEntity.BaseType return an option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,12 @@ docs/output
 *.bak
 temp/
 src/fsharp/fsi/FSIStrings.fs
+
+src/fsharp/FSharp.Compiler.Service/FSComp.resx
+src/fsharp/FSharp.Compiler.Service/FSIstrings.resx
+src/fsharp/FSharp.Compiler.Service/illex.fs
+src/fsharp/FSharp.Compiler.Service/ilpars.fs
+src/fsharp/FSharp.Compiler.Service/ilpars.fsi
+src/fsharp/FSharp.Compiler.Service/lex.fs
+src/fsharp/FSharp.Compiler.Service/pars.fs
+src/fsharp/FSharp.Compiler.Service/pars.fsi

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -72,3 +72,5 @@
 #### 0.0.15 - 
 * Update version number as nuget package may not have published properly
 
+#### 0.0.16 - 
+* Make FSharpEntity.BaseType return an option

--- a/src/assemblyinfo/assemblyinfo.shared.fs
+++ b/src/assemblyinfo/assemblyinfo.shared.fs
@@ -1,9 +1,9 @@
 ﻿namespace System
 open System.Reflection
 
-[<assembly: AssemblyVersionAttribute("0.0.15")>]
-[<assembly: AssemblyFileVersionAttribute("0.0.15")>]
+[<assembly: AssemblyVersionAttribute("0.0.16")>]
+[<assembly: AssemblyFileVersionAttribute("0.0.16")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.0.15"
+    let [<Literal>] Version = "0.0.16"

--- a/src/fsharp/vs/Typed.fs
+++ b/src/fsharp/vs/Typed.fs
@@ -224,10 +224,8 @@ type FSharpEntity(g:TcGlobals, entity:EntityRef) =
         entity.ImmediateInterfaceTypesOfFSharpTycon |> List.map (fun ty -> FSharpType(g, ty)) |> makeReadOnlyCollection
 
     member this.BaseType = 
-        checkIsResolved()
-        match entity.TypeContents.tcaug_super with 
-        | None -> invalidOp "this entity has no base type"
-        | Some ty -> FSharpType(g, ty)
+        checkIsResolved()        
+        entity.TypeContents.tcaug_super |> Option.map (fun ty -> FSharpType(g, ty)) 
         
     member __.UsesPrefixDisplay = 
         if isUnresolved() then true else

--- a/src/fsharp/vs/Typed.fsi
+++ b/src/fsharp/vs/Typed.fsi
@@ -171,7 +171,7 @@ and [<Class>] FSharpEntity =
     member DeclaredInterfaces : IList<FSharpType>  
 
     /// Get the base type, if any 
-    member BaseType : FSharpType
+    member BaseType : FSharpType option
 
     /// Get the properties, events and methods of a type definitions, or the functions and values of a module
     member MembersFunctionsAndValues : IList<FSharpMemberFunctionOrValue>


### PR DESCRIPTION
This is needed to be able to implement https://github.com/tpetricek/FSharp.Formatting/issues/55
