### PR TITLE
Fix to build Japanese documents correctly.

### DIFF
--- a/docs/tools/generate.ja.fsx
+++ b/docs/tools/generate.ja.fsx
@@ -20,11 +20,13 @@ let info =
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../bin"
 #I "../../packages/FSharp.Formatting.2.3.4-beta/lib/net40"
-#I "../../packages/RazorEngine.3.3.0/lib/net40/"
+#I "../../packages/RazorEngine.3.3.0/lib/net40"
 #r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
+#I "../../packages/FSharp.Compiler.Service.0.0.11-alpha/lib/net40"
+#I "../../packages/FAKE/tools"
 #r "../../packages/FAKE/tools/FakeLib.dll"
+#r "FSharp.Compiler.Service.dll"
 #r "RazorEngine.dll"
 #r "FSharp.Literate.dll"
 #r "FSharp.CodeFormat.dll"


### PR DESCRIPTION
I found that Japanese documents are not generated correctly because generate.ja.fsx has wrong reference paths.
