### PR TITLE
Fix failed test in FscTests.fs.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -83,6 +83,12 @@ Target "Build" (fun _ ->
 )
 
 
+Target "PrepareTests" (fun _ ->
+    let target = "bin"
+    let files = !! "packages/FAKE/tools/FSharp.Core.*data"
+    Copy target files
+)
+
 // --------------------------------------------------------------------------------------
 // Run the unit tests using test runner & kill test runner when complete
 
@@ -103,6 +109,13 @@ Target "RunTests" (fun _ ->
 
 FinalTarget "CloseTestRunner" (fun _ ->  
     ProcessHelper.killProcess "nunit-agent.exe"
+)
+
+Target "CleanupTests" (fun _ ->
+    !! "bin/Foo.*"
+    ++ "bin/Bar.*"
+    ++ "bin/FSharp.Core.*data"
+    |> DeleteFiles
 )
 
 // --------------------------------------------------------------------------------------
@@ -167,7 +180,9 @@ Target "All" DoNothing
   ==> "GenerateFSIStrings"
   ==> "Prepare"
   ==> "Build"
+  ==> "PrepareTests"
   ==> "RunTests" 
+  ==> "CleanupTests"
   ==> "All"
 
 "All"

--- a/tests/service/FscTests.fs
+++ b/tests/service/FscTests.fs
@@ -90,8 +90,8 @@ let compileAndVerify isDll debugMode (assemblyName : string) (code : string) (de
     let verifier = new PEVerifier ()
     let tmp = Path.GetTempPath()
     let sourceFile = Path.Combine(tmp, assemblyName + ".fs")
-    let outFile = Path.Combine(tmp, assemblyName + if isDll then ".dll" else ".exe")
-    let pdbFile = Path.Combine(tmp, assemblyName + pdbExtension isDll)
+    let outFile = assemblyName + (if isDll then ".dll" else ".exe")
+    let pdbFile = assemblyName + (pdbExtension isDll)
     do File.WriteAllText(sourceFile, code)
     let args =
         [|
@@ -111,6 +111,10 @@ let compileAndVerify isDll debugMode (assemblyName : string) (code : string) (de
                 yield "--debug:full"
                 if not runningOnMono then // on Mono, the debug file name is not configurable
                     yield sprintf "--pdb:%s" pdbFile
+
+            // try to use local FSharp.Core.dll, instead.
+            yield "--noframework"
+            yield "-r:FSharp.Core.dll"
 
             for d in dependencies do
                 yield sprintf "-r:%s" d


### PR DESCRIPTION
I found that compiled assemblies built by FscTests.fs are placed in the temporary folder,
but it causes missing reference errors on my environment.
So I changed to generate them under 'bin' directory and use local FSharp.Core.dll, instead.
Please reject my PR if you already have better way.
Thanks,
