### PR TITLE
Add a failing test for issue #114

### DIFF
--- a/tests/service/EditorTests.fs
+++ b/tests/service/EditorTests.fs
@@ -204,3 +204,26 @@ let ``Expression typing test`` () =
                "Length"; "Normalize"; "PadLeft"; "PadRight"; "Remove"; "Replace"; "Split";
                "StartsWith"; "Substring"; "ToCharArray"; "ToLower"; "ToLowerInvariant";
                "ToString"; "ToUpper"; "ToUpperInvariant"; "Trim"; "TrimEnd"; "TrimStart"])
+
+
+[<Test>]
+let ``ToolTip description wait is respected`` () = 
+    // Make sure that the spinwait delay is respected when 
+    // getting descriptions for Autocomplete entries
+    let input = "let mystring = \"\"."
+
+    let file = "/home/user/Test.fsx"
+    let untyped, typeCheckResults =  parseAndTypeCheckFileInProject(file, input3) 
+
+    let decls =  typeCheckResults.GetDeclarationsAlternate(Some untyped, 2, 17, input, [], "", fun _ -> false)|> Async.RunSynchronously
+    let item = decls.Items.[0];
+    
+    let sw = System.Diagnostics.Stopwatch()
+    sw.Start()
+    let description = item.DescriptionText
+    sw.Stop();
+    
+    let isLoading = description = ToolTipText [ ToolTipElement("(loading description...)", XmlCommentNone) ]
+    if isLoading then
+       Assert.GreaterOrEqual(sw.ElapsedMilliseconds, 300L)
+    else Assert.Inconclusive()


### PR DESCRIPTION
See #114

Running this test in VS yields an assert: 

```
Bug in target of HandleAsyncOp: System.Threading.ThreadAbortException: Thread was being aborted.
The most recent error reported to an error scope: "   at Microsoft.FSharp.Compiler.ErrorScope.Protect[a](range m, FSharpFunc`2 f, FSharpFunc`2 err) in src\fsharp\vs\IncrementalBuild.fs:line 1076
   at Microsoft.FSharp.Compiler.SourceCodeServices.ItemDescriptionsImpl.FormatDescriptionOfItem(Boolean isDecl, InfoReader infoReader, range m, DisplayEnv denv, Item d) in src\fsharp\vs\ServiceDeclarations.fs:line 1132
   at <StartupCode$FSharp-Compiler-Service>.$ServiceDeclarations.description@1260.Invoke(Item arg40@) in src\fsharp\vs\ServiceDeclarations.fs:line 1260
   at Microsoft.FSharp.Primitives.Basics.List.map[T,TResult](FSharpFunc`2 mapping, FSharpList`1 x)
   at Microsoft.FSharp.Collections.ListModule.Map[T,TResult](FSharpFunc`2 mapping, FSharpList`1 list)
   at <StartupCode$FSharp-Compiler-Service>.$ServiceDeclarations.work@1254-1.Invoke(Unit unitVar0) in src\fsharp\vs\ServiceDeclarations.fs:line 1260
   at Microsoft.FSharp.Compiler.SourceCodeServices.Reactor.HandleAsyncOp@89T.Invoke(FSharpFunc`2 op, b state) in src\fsharp\vs\Reactor.fs:line 91"

   at Microsoft.FSharp.Compiler.SourceCodeServices.Reactor.HandleAsyncOp@89T.Invoke(FSharpFunc`2 op, b state) in src\fsharp\vs\Reactor.fs:line 96
   at Microsoft.FSharp.Compiler.SourceCodeServices.Reactor.loop@156-79.Invoke(ReactorCommands _arg2) in src\fsharp\vs\Reactor.fs:line 162
   at Microsoft.FSharp.Control.AsyncBuilderImpl.args@753.Invoke(a a)
   at <StartupCode$FSharp-Core>.$Control.loop@419-40(Trampoline this, FSharpFunc`2 action)
   at Microsoft.FSharp.Control.Trampoline.ExecuteAction(FSharpFunc`2 firstAction)
   at Microsoft.FSharp.Control.TrampolineHolder.Protect(FSharpFunc`2 firstAction)
   at <StartupCode$FSharp-Core>.$Control.-ctor@476-1.Invoke(Object state)
   at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
```
