### PR TITLE
Put .NET 4.0  and .NET 4.5 into nuget package - I hope this time for real.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -230,3 +230,6 @@
 #### 0.0.55 - 
 * Integrate changes for F# 3.1.x, Fix #166
 * Fix for #160 - Nuget package contains .NET 4.0 and 4.5
+
+#### 0.0.56 - 
+* Second fix for #160 - Nuget package now contains .NET 4.0 and 4.5

--- a/build.fsx
+++ b/build.fsx
@@ -87,7 +87,7 @@ Target "Build" (fun _ ->
         let outputPath = "bin/" + framework.Replace(".","")
         !! (project + ".sln")
         |> MSBuild outputPath "Build" ["Configuration","Release"; "TargetFrameworkVersion", framework]
-        |> Log ".NET 4.0 Build-Output: "
+        |> Log (".NET " + framework + " Build-Output: ")
 
         MoveFile outputPath "./bin/FSharp.Compiler.Service.xml")
 )

--- a/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/src/fsharp/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 # Copyright (c) 2002-2011 Microsoft Corporation. 
 #
@@ -18,7 +18,7 @@
     <NoWarn>$(NoWarn);44;62;9</NoWarn>
     <ProjectGuid>{2E4D67B4-522D-4CF7-97E4-BA940F0B18F3}</ProjectGuid>
     <AllowCrossTargeting>true</AllowCrossTargeting>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.5</TargetFrameworkVersion>
     <BaseAddress>0x06800000</BaseAddress>
     <OtherFlags>$(OtherFlags) /warnon:1182</OtherFlags>
     <Tailcalls>true</Tailcalls>
@@ -63,6 +63,12 @@
     <Optimize>true</Optimize>
     <DocumentationFile>..\..\..\bin\FSharp.Compiler.Service.XML</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFrameworkVersion) == 'v4.0'">
+    <DefineConstants>$(DefineConstants);NET40</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFrameworkVersion) == 'v4.5'">
+    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
+  </PropertyGroup>  
   <ItemGroup>
     <Compile Include="..\..\assemblyinfo\assemblyinfo.FSharp.Compiler.Service.dll.fs">
       <Link>AssemblyInfo/assemblyinfo.FSharp.Compiler.Service.dll.fs</Link>


### PR DESCRIPTION
DotPeek is showing the right framework versions now:

![image](https://cloud.githubusercontent.com/assets/57396/3385917/3cddb3ae-fc6f-11e3-946f-38d8da1dc3ed.png)

and FAKE is not complaining any more. Hope it's finally fixed. Sorry
