### PR TITLE
The FSharp.Core should be retrieved from the hosting environment

### DIFF
--- a/src/fsharp/build.fs
+++ b/src/fsharp/build.fs
@@ -1563,10 +1563,13 @@ let GetFSharpCoreReferenceUsedByCompiler(useMonoResolution) =
 
     // check if FSharp.Core can be found from the hosting environment
     let foundReference =
-        System.Reflection.Assembly.GetEntryAssembly().GetReferencedAssemblies()
-        |> Array.tryPick (fun name ->
-            if name.Name = fsCoreName then Some(name.ToString())
-            else None)
+        match System.Reflection.Assembly.GetEntryAssembly() with
+        | null -> None
+        | entryAssembly ->
+            entryAssembly.GetReferencedAssemblies()
+            |> Array.tryPick (fun name ->
+                if name.Name = fsCoreName then Some(name.ToString())
+                else None)
 
     // if not we use the referenced FSharp.Core from this project
     match foundReference with


### PR DESCRIPTION
- fixes #156 and https://github.com/fsharp/FAKE/issues/486

I also fixes FSharp.Core.dll resolution in FSharp.Formatting.

DISCLAIMER:

![uvj9hf7](https://cloud.githubusercontent.com/assets/57396/3441652/84a744f6-0107-11e4-8f63-72511e0d6b81.gif)
