### PR TITLE
Add TryFullName to FSharpEntity

### DIFF
--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -182,7 +182,14 @@ and FSharpEntity(g:TcGlobals, thisCcu, tcImports: TcImports, entity:EntityRef) =
         match entity.CompiledRepresentation with 
         | CompiledTypeRepr.ILAsmNamed(tref,_,_) -> tref.FullName
         | CompiledTypeRepr.ILAsmOpen _ -> fail()
-        
+    
+    member x.TryFullName = 
+        if isUnresolved() then None
+        elif entity.IsTypeAbbrev then None
+        else
+            match entity.CompiledRepresentation with 
+            | CompiledTypeRepr.ILAsmNamed(tref,_,_) -> Some tref.FullName
+            | CompiledTypeRepr.ILAsmOpen _ -> None   
 
     member __.DeclarationLocation = 
         checkIsResolved()

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -117,6 +117,9 @@ and [<Class>] FSharpEntity =
     /// Get the full name of the type or module
     member FullName: string 
 
+    /// Get the full name of the type or module if it is available
+    member TryFullName: string option
+
     /// Get the declaration location for the type constructor 
     member DeclarationLocation: range 
 


### PR DESCRIPTION
`FSharpEntity.FullName` is the only source of scope information in FCS.

We use `FSharpEntity.FullName` extensively in VFPT. It occasionally throws exceptions which lead to bad performance in tight loops.  

Although `TryFullName` is a bit ad-hoc, it gives reasonable performance in tight loops. `FullName` should still be used in normal circumstances.
