### PR TITLE
Return associated getters/setters from F# properties

### DIFF
--- a/src/fsharp/vs/Symbols.fs
+++ b/src/fsharp/vs/Symbols.fs
@@ -913,6 +913,44 @@ and FSharpMemberFunctionOrValue(g:TcGlobals, thisCcu, tcImports, d:FSharpMemberO
             | V v -> v.TauType
         FSharpType(g, thisCcu, tcImports,  ty)
 
+    member __.HasGetterMethod =
+        if isUnresolved() then false
+        else
+            match d with 
+            | P m -> m.HasGetter
+            | E _
+            | M _
+            | V _ -> false
+
+    member __.GetterMethod =
+        checkIsResolved()
+        match d with 
+        | P m -> 
+            let minfo = m.GetterMethod
+            FSharpMemberFunctionOrValue(g, thisCcu, tcImports, M minfo, Item.MethodGroup (minfo.DisplayName,[minfo]))
+        | E _
+        | M _
+        | V _ -> invalidOp "the value or member doesn't have an associated getter method" 
+
+    member __.HasSetterMethod =
+        if isUnresolved() then false
+        else
+            match d with 
+            | P m -> m.HasSetter
+            | E _
+            | M _
+            | V _ -> false
+
+    member __.SetterMethod =
+        checkIsResolved()
+        match d with 
+        | P m -> 
+            let minfo = m.SetterMethod
+            FSharpMemberFunctionOrValue(g, thisCcu, tcImports, M minfo, Item.MethodGroup (minfo.DisplayName,[minfo]))
+        | E _
+        | M _
+        | V _ -> invalidOp "the value or member doesn't have an associated setter method" 
+
     member __.EnclosingEntity = 
         checkIsResolved()
         match d with 

--- a/src/fsharp/vs/Symbols.fsi
+++ b/src/fsharp/vs/Symbols.fsi
@@ -564,6 +564,18 @@ and [<Class>] FSharpMemberFunctionOrValue =
     /// Indicates if this is a property member
     member IsProperty : bool
 
+    /// Indicates if this is a property then there exists an associated getter method
+    member HasGetterMethod : bool
+
+    /// Get an associated getter method of the property
+    member GetterMethod : FSharpMemberFunctionOrValue
+
+    /// Indicates if this is a property then there exists an associated setter method
+    member HasSetterMethod : bool
+
+    /// Get an associated setter method of the property
+    member SetterMethod : FSharpMemberFunctionOrValue
+
     /// Indicates if this is an event member
     member IsEvent : bool
 


### PR DESCRIPTION
Close #178.
Close #191.

This PR exposes associated getters/setters' symbols from properties' symbols. It allows us to bypass imprecision of F# properties' symbols in many cases.

We have a hack to return getters/setters from extension properties at https://github.com/fsprojects/VisualFSharpPowerTools/blob/faa1b282dd4e740c36651ba8a85c8f9fdd89a04b/src/FSharpVSPowerTools.Core/LanguageService.fs#L432-L450, but I believe it consists of subtle bugs. It is a relief to be able to get rid of this hack.
