### PR TITLE
Add logging to project cracking facility

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
 
-mono .nuget/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion
-mono .nuget/NuGet.exe install FSharp.Formatting -OutputDirectory packages -ExcludeVersion
-mono .nuget/NuGet.exe install SourceLink.Fake -OutputDirectory packages -ExcludeVersion
+if [[ ! -e ~/.config/.mono/certs ]];
+then
+    mozroots --import --sync --quiet
+fi
 
-mono packages/FAKE/tools/FAKE.exe build.fsx -d:MONO $@
+if [[ ! -e packages/FAKE/tools/FAKE.exe ]];
+then
+    mono .nuget/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion
+fi
+
+if [[ ! -e packages/FSharp.Formatting/lib/net40/FSharp.Literate.dll ]];
+then
+    mono .nuget/NuGet.exe install FSharp.Formatting -OutputDirectory packages -ExcludeVersion
+fi
+
+if [[ ! -e packages/SourceLink.Fake/tools/SourceLink.dll ]];
+then
+    mono .nuget/NuGet.exe install SourceLink.Fake -OutputDirectory packages -ExcludeVersion
+fi
+
+mono packages/FAKE/tools/FAKE.exe build.fsx -d:MONO "$@"

--- a/docs/content/project.fsx
+++ b/docs/content/project.fsx
@@ -6,7 +6,7 @@ Compiler Services: Project Analysis
 
 This tutorial demonstrates how to can analyze a whole project using services provided by the F# compiler.
 
-> **NOTE:** The FSharp.Compiler.Service API is subject to change when later versions of the nuget package are published
+> **NOTE:** The FSharp.Compiler.Service API is subject to change when later versions of the nuget package are published.
 
 *)
 
@@ -293,11 +293,15 @@ correctly and then analyze each project in turn.
 > **NOTE:** Project references are in prototype.  Using project references may currently degrade the responsiveness of the 
   compiler service, because requests may not yet be serviced while dependent projects are being analyzed.
 
+*)
+
+(**
+
 > **NOTE:** Project references are disabled if the assembly being referred to contains type provider components - 
   specifying the project reference will have no effect beyond forcing the analysis of the project, and the DLL will 
   still be required on disk.
 
-**)
+*)
 
 (**
 Cracking a project file
@@ -306,7 +310,7 @@ Cracking a project file
 F# projects normally use the '.fsproj' project file format.  You can get options corresponding to a project file
 using GetProjectOptionsFromProjectFile.  In this example we get the project options for one of the 
 project files in the F# Compiler Service project itself - you should also be able to use this technique
-for any project that cleans buildly using the command line tools 'xbuild' or 'msbuild'.
+for any project that builds cleanly using the command line tools 'xbuild' or 'msbuild'.
 
 
 *)
@@ -326,7 +330,7 @@ checker.GetProjectOptionsFromProjectFile(projectFile, [("Configuration", "Releas
 
 (**
 
-Another utility is provided to simply get the command line arguments for a project file
+Another utility is provided to obtain a detailed view of the resolved and processed project file. The returned object can be used to access the fully resolved references, source files that will be included during compilation, and other options.
 
 *)
 
@@ -334,8 +338,12 @@ FSharpProjectFileInfo.Parse(projectFile, [("Configuration", "Release")])
 
 (**
 
-Here a detailed view of the resolved and processed project file is returned.
+For debugging purposes it is also possible to obtain a detailed log from the assembly resolution process.
+
 *)
+
+let p = FSharpProjectFileInfo.Parse(projectFile, enableLogging=true)
+Console.WriteLine(p.LogOutput)
 
 (**
 Summary

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -21,8 +21,8 @@ let info =
 // --------------------------------------------------------------------------------------
 
 #I "../../packages/FSharp.Formatting/lib/net40"
-#I "../../packages/RazorEngine.3.3.0/lib/net40"
-#r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
+#I "../../packages/RazorEngine/lib/net40"
+#r "../../packages/Microsoft.AspNet.Razor/lib/net40/System.Web.Razor.dll"
 #I "../../packages/FSharp.Compiler.Service/lib/net45"
 #I "../../packages/FAKE/tools"
 #r "../../packages/FAKE/tools/FakeLib.dll"

--- a/docs/tools/generate.ja.fsx
+++ b/docs/tools/generate.ja.fsx
@@ -21,8 +21,8 @@ let info =
 // --------------------------------------------------------------------------------------
 
 #I "../../packages/FSharp.Formatting/lib/net40"
-#I "../../packages/RazorEngine.3.3.0/lib/net40"
-#r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
+#I "../../packages/RazorEngine/lib/net40"
+#r "../../packages/Microsoft.AspNet.Razor/lib/net40/System.Web.Razor.dll"
 #I "../../packages/FSharp.Compiler.Service/lib/net45"
 #I "../../packages/FAKE/tools"
 #r "../../packages/FAKE/tools/FakeLib.dll"

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -355,7 +355,7 @@ type FSharpCheckFileAnswer =
 /// Represents the information gathered by parsing and processing a .fsproj project file format.
 type FSharpProjectFileInfo =
     /// Parse and process a .fsproj file 
-    static member Parse : fsprojFileName: string * ?properties: (string * string) list -> FSharpProjectFileInfo
+    static member Parse : fsprojFileName: string * ?properties: (string * string) list * ?enableLogging: bool -> FSharpProjectFileInfo
     /// The command-line arguments for compiling this project
     member Options : string list
     /// The FrameworkVersion for the project
@@ -380,6 +380,8 @@ type FSharpProjectFileInfo =
     member OutputPath : string option
     /// The full path to the project file
     member FullPath : string 
+    /// Logging output from the build if requested
+    member LogOutput : string
 #endif
 #endif
 

--- a/tests/service/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/service/FSharp.Compiler.Service.Tests.fsproj
@@ -85,6 +85,7 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="Microsoft.Build, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(TargetFrameworkVersion)' == 'v4.5'" />
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
 </Project>

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -4031,3 +4031,180 @@ let ``Test project31 Format C# method attributes`` () =
         |> shouldEqual 
               (set ["[<CLSCompliantAttribute (false)>]";
                     "[<Security.SecuritySafeCriticalAttribute ()>]"])
+#if FX_ATLEAST_45
+
+let checkOption (opts:string[]) s = 
+    let found = "Found '"+s+"'"
+    (if opts |> Array.exists (fun o -> o.EndsWith(s)) then found else "Failed to find '"+s+"'")
+       |> shouldEqual found
+
+let checkOptionNotPresent (opts:string[]) s = 
+    let found = "Found '"+s+"'"
+    let notFound = "Did not expect to find '"+s+"'"
+    (if opts |> Array.exists (fun o -> o.EndsWith(s)) then found else notFound)
+       |> shouldEqual notFound
+
+[<Test>]
+let ``Project file parsing example 1 Default Configuration`` () = 
+  // BUG - see https://github.com/fsharp/FSharp.Compiler.Service/issues/237
+//  if not runningOnMono then 
+
+    let projectFile = __SOURCE_DIRECTORY__ + @"/FSharp.Compiler.Service.Tests.fsproj"
+    let options = checker.GetProjectOptionsFromProjectFile(projectFile)
+
+    printfn "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv" 
+    printfn "PROJ FILE %s" projectFile
+    printfn "%A" options.OtherOptions
+    printfn "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" 
+
+    checkOption options.OtherOptions "FSharp.Compiler.Service.dll"
+    checkOption options.OtherOptions "FileSystemTests.fs"
+    checkOption options.OtherOptions "--define:TRACE"
+    checkOption options.OtherOptions "--define:DEBUG"
+    checkOption options.OtherOptions "--flaterrors"
+    checkOption options.OtherOptions "--simpleresolution"
+    checkOption options.OtherOptions "--noframework"
+
+[<Test>]
+let ``Project file parsing example 1 Release Configuration`` () = 
+  // BUG - see https://github.com/fsharp/FSharp.Compiler.Service/issues/237
+//  if not runningOnMono then 
+    let projectFile = __SOURCE_DIRECTORY__ + @"/FSharp.Compiler.Service.Tests.fsproj"
+    // Check with Configuration = Release
+    let options = checker.GetProjectOptionsFromProjectFile(projectFile, [("Configuration", "Release")])
+
+    printfn "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv" 
+    printfn "PROJ FILE %s" projectFile
+    printfn "%A" options.OtherOptions
+    printfn "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" 
+    checkOption options.OtherOptions "FSharp.Compiler.Service.dll"
+    checkOption options.OtherOptions "FileSystemTests.fs"
+    checkOption options.OtherOptions "--define:TRACE"
+    checkOptionNotPresent options.OtherOptions "--define:DEBUG"
+    checkOption options.OtherOptions "--debug:pdbonly"
+
+[<Test>]
+let ``Project file parsing VS2013_FSharp_Portable_Library_net45``() = 
+  // BUG - see https://github.com/fsharp/FSharp.Compiler.Service/issues/237
+  if not runningOnMono then 
+    let projectFile = __SOURCE_DIRECTORY__ + @"/../projects/Sample_VS2013_FSharp_Portable_Library_net45/Sample_VS2013_FSharp_Portable_Library_net45.fsproj"
+    let options = checker.GetProjectOptionsFromProjectFile(projectFile, [])
+
+    printfn "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv" 
+    printfn "PROJ FILE %s" projectFile
+    printfn "%A" options.OtherOptions
+    printfn "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" 
+
+    checkOption options.OtherOptions "--targetprofile:netcore"
+    checkOption options.OtherOptions "--tailcalls-"
+
+    checkOption options.OtherOptions "FSharp.Core.dll"
+    checkOption options.OtherOptions "Microsoft.CSharp.dll"
+    checkOption options.OtherOptions "System.Runtime.dll"
+    checkOption options.OtherOptions "System.Net.Requests.dll"
+    checkOption options.OtherOptions "System.Xml.XmlSerializer.dll"
+
+[<Test>]
+let ``Project file parsing Sample_VS2013_FSharp_Portable_Library_net451_adjusted_to_profile78``() = 
+  // BUG - see https://github.com/fsharp/FSharp.Compiler.Service/issues/237
+  if not runningOnMono then 
+    let projectFile = __SOURCE_DIRECTORY__ + @"/../projects/Sample_VS2013_FSharp_Portable_Library_net451_adjusted_to_profile78/Sample_VS2013_FSharp_Portable_Library_net451.fsproj"
+    let options = checker.GetProjectOptionsFromProjectFile(projectFile, [])
+
+    printfn "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv" 
+    printfn "PROJ FILE %s" projectFile
+    printfn "%A" options.OtherOptions
+    printfn "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" 
+    checkOption options.OtherOptions "--targetprofile:netcore"
+    checkOption options.OtherOptions "--tailcalls-"
+
+    checkOption options.OtherOptions "FSharp.Core.dll"
+    checkOption options.OtherOptions "Microsoft.CSharp.dll"
+    checkOption options.OtherOptions "System.Runtime.dll"
+    checkOption options.OtherOptions "System.Net.Requests.dll"
+    checkOption options.OtherOptions "System.Xml.XmlSerializer.dll"
+
+[<Test>]
+let ``Project file parsing -- compile files 1``() =
+  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj")
+
+  p.CompileFiles
+  |> List.map Path.GetFileName
+  |> set
+  |> should equal (set [ "Test1File1.fs"; "Test1File2.fs" ])
+
+[<Test>]
+let ``Project file parsing -- compile files 2``() =
+  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test2.fsproj")
+
+  p.CompileFiles
+  |> List.map Path.GetFileName
+  |> set
+  |> should equal (set [ "Test2File1.fs"; "Test2File2.fs" ])
+
+[<Test>]
+let ``Project file parsing -- bad project file``() =
+  (fun () -> FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Malformed.fsproj") |> ignore)
+  |> should throw typeof<Microsoft.Build.Exceptions.InvalidProjectFileException>
+
+[<Test>]
+let ``Project file parsing -- non-existent project file``() =
+  (fun () -> FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/DoesNotExist.fsproj") |> ignore)
+  |> should throw typeof<System.IO.FileNotFoundException>
+
+[<Test>]
+let ``Project file parsing -- output file``() =
+  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj")
+
+  let expectedOutputPath =
+    (new Uri(__SOURCE_DIRECTORY__ + "/data/Test1/bin/Debug/Test1.dll")).LocalPath
+
+  p.OutputFile
+  |> should equal (Some expectedOutputPath)
+
+[<Test>]
+let ``Project file parsing -- references``() =
+  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test1.fsproj")
+
+  checkOption (Array.ofList p.References) "FSharp.Core.dll"
+  checkOption (Array.ofList p.References) "mscorlib.dll"
+  checkOption (Array.ofList p.References) "System.Core.dll"
+  checkOption (Array.ofList p.References) "System.dll"
+  p.References |> should haveLength 4
+
+[<Test>]
+let ``Project file parsing -- 2nd level references``() =
+  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/Test2.fsproj")
+
+  checkOption (Array.ofList p.References) "FSharp.Core.dll"
+  checkOption (Array.ofList p.References) "mscorlib.dll"
+  checkOption (Array.ofList p.References) "System.Core.dll"
+  checkOption (Array.ofList p.References) "System.dll"
+  checkOption (Array.ofList p.References) "Test1.dll"
+  p.References |> should haveLength 5
+
+[<Test>]
+let ``Project file parsing -- Tools Version 12``() =
+  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/ToolsVersion12.fsproj")
+
+  checkOption (Array.ofList p.References) "System.Core.dll"
+
+[<Test>]
+let ``Project file parsing -- Logging``() =
+  let p = FSharpProjectFileInfo.Parse(__SOURCE_DIRECTORY__ + @"/data/ToolsVersion12.fsproj", enableLogging=true)
+
+  if runningOnMono then
+    Assert.That(p.LogOutput, Is.StringContaining("Reference System.Core resolved"))
+    Assert.That(p.LogOutput, Is.StringContaining("Target named 'ImplicitlyExpandTargetFramework'"))
+    Assert.That(p.LogOutput, Is.StringContaining("Using task ResolveAssemblyReference from Microsoft.Build.Tasks.ResolveAssemblyReference, Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"))
+  else
+    Assert.That(p.LogOutput, Is.StringContaining("""Using "ResolveAssemblyReference" task from assembly "Microsoft.Build.Tasks.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"."""))
+    Assert.That(p.LogOutput, Is.StringContaining("""target "ImplicitlyExpandTargetFramework"""))
+
+[<Test>]
+let ``Project file parsing -- Full path``() =
+  let f = (new Uri(__SOURCE_DIRECTORY__ + @"/data/ToolsVersion12.fsproj")).LocalPath
+  let p = FSharpProjectFileInfo.Parse(f)
+
+  p.FullPath |> should equal f
+#endif

--- a/tests/service/data/Malformed.fsproj
+++ b/tests/service/data/Malformed.fsproj
@@ -1,0 +1,1 @@
+Not even slightly like a project

--- a/tests/service/data/Test1.fsproj
+++ b/tests/service/data/Test1.fsproj
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73da}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Test1</RootNamespace>
+    <AssemblyName>Test1</AssemblyName>
+    <Name>Test1</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>Test1\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\Test1.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>Test1\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\Test1.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Test1File2.fs" />
+    <Compile Include="Test1File1.fs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/tests/service/data/Test2.fsproj
+++ b/tests/service/data/Test2.fsproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73db}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Test2</RootNamespace>
+    <AssemblyName>Test2</AssemblyName>
+    <Name>Test2</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>Test2\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\Test2.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>Test2\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\Test2.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Test2File2.fs" />
+    <Compile Include="Test2File1.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="Test1.fsproj">
+      <Project>{116cc2f9-f987-4b3d-915a-34cac04a73da}</Project>
+      <Name>Test1</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/tests/service/data/ToolsVersion12.fsproj
+++ b/tests/service/data/ToolsVersion12.fsproj
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>00000000-0000-0000-0000-000000000002</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Main</RootNamespace>
+    <AssemblyName>Main</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <Name>Main</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="main.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Test\test.fsproj">
+      <Name>Interfaces</Name>
+      <Project>{00000000-0000-0000-0000-000000000001}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
Also add more tests, and wrapping of the invalidprojectfileexception so
that only one exception type need be caught (the new API type).
