### PR TITLE
Split some SILVERLIGHT flags into separate parts

### DIFF
--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -492,7 +492,7 @@ let DumpDebugInfo (outfile:string) (info:PdbData) =
 // Strong name signing
 //---------------------------------------------------------------------
 
-#if SILVERLIGHT
+#if NO_STRONGNAME_SIGNER
 type ILStrongNameSigner =  
     | NeverImplemented
     static member OpenPublicKeyFile (_s:string) = NeverImplemented
@@ -4083,7 +4083,7 @@ let writeBinaryAndReportMappings (outfile, ilg, pdbfile: string option, signer: 
           let dataSectionAddr = next
           let dataSectionVirtToPhys v = v - dataSectionAddr + dataSectionPhysLoc
           
-#if SILVERLIGHT
+#if NO_NATIVE_RESOURCES
           let nativeResources = [| |]
 #else
           let resourceFormat = if modul.Is64Bit then Support.X64 else Support.X86

--- a/src/fsharp/build.fs
+++ b/src/fsharp/build.fs
@@ -5421,7 +5421,7 @@ let compilerOptionUsage (CompilerOption(s,tag,spec,_,_)) =
 let printCompilerOption (CompilerOption(_s,_tag,_spec,_,help) as compilerOption) =
     let flagWidth = 30 // fixed width for printing of flags, e.g. --warnaserror:<warn;...>
     let defaultLineWidth = 80 // the fallback width
-#if SILVERLIGHT
+#if LIMITED_CONSOLE
     let lineWidth = defaultLineWidth
 #else        
     let lineWidth = try System.Console.BufferWidth with e -> defaultLineWidth

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1863,7 +1863,7 @@ let main0(argv,bannerAlreadyPrinted,openBinariesInMemory:bool,exiter:Exiter, err
 
     // See Bug 735819 
     let lcidFromCodePage = 
-#if SILVERLIGHT
+#if LIMITED_CONSOLE
         None
 #else
         if (System.Console.OutputEncoding.CodePage <> 65001) &&
@@ -1882,7 +1882,7 @@ let main0(argv,bannerAlreadyPrinted,openBinariesInMemory:bool,exiter:Exiter, err
         let curDir = Directory.GetCurrentDirectory()
 #endif
         getTcImportsFromCommandLine(None, argv, defaultFSharpBinariesDir, curDir, lcidFromCodePage, (fun tcConfigB ->
-#if SILVERLIGHT
+#if LIMITED_CONSOLE
                           ()
 #else
                           tcConfigB.openBinariesInMemory <- openBinariesInMemory

--- a/src/fsharp/fscopts.fs
+++ b/src/fsharp/fscopts.fs
@@ -985,7 +985,7 @@ let fsharpModuleName (t:CompilerTarget) (s:string) =
 let ignoreFailureOnMono1_1_16 f = try f() with _ -> ()
 
 let DoWithErrorColor isWarn f =
-#if SILVERLIGHT
+#if LIMITED_CONSOLE
     ignore (isWarn : bool)
     f()
 #else    

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -654,7 +654,7 @@ type internal FsiCommandLineOptions(fsiConfig: FsiEvaluationSessionHostConfig, a
             stopProcessingRecovery e range0; failwithf "Error creating evaluation session: %A" e
         inputFilesAcc
 
-#if SILVERLIGHT
+#if LIMITED_CONSOLE
 #else
     do 
         if tcConfigB.utf8output then
@@ -748,7 +748,7 @@ let internal InstallErrorLoggingOnThisThread errorLogger =
 /// Set the input/output encoding. The use of a thread is due to a known bug on 
 /// on Vista where calls to Console.InputEncoding can block the process.
 let internal SetServerCodePages(fsiOptions: FsiCommandLineOptions) =     
-#if SILVERLIGHT
+#if LIMITED_CONSOLE
     ignore fsiOptions
 #else     
     match fsiOptions.FsiServerInputCodePage, fsiOptions.FsiServerOutputCodePage with 
@@ -2289,8 +2289,8 @@ type FsiEvaluationSession (fsiConfig: FsiEvaluationSessionHostConfig, argv:strin
     do if not runningOnMono then Lib.UnmanagedProcessExecutionOptions.EnableHeapTerminationOnCorruption() (* SDL recommendation *)
     // See Bug 735819 
     let lcidFromCodePage = 
-#if SILVERLIGHT
-#else         
+#if LIMITED_CONSOLE
+#else
         if (Console.OutputEncoding.CodePage <> 65001) &&
            (Console.OutputEncoding.CodePage <> Thread.CurrentThread.CurrentUICulture.TextInfo.OEMCodePage) &&
            (Console.OutputEncoding.CodePage <> Thread.CurrentThread.CurrentUICulture.TextInfo.ANSICodePage) then

--- a/src/utils/CompilerLocationUtils.fs
+++ b/src/utils/CompilerLocationUtils.fs
@@ -84,12 +84,16 @@ module internal FSharpEnvironment =
     let REG_SZ = 1u
 
     let GetDefaultRegistryStringValueViaDotNet(subKey: string)  =
+#if NO_WIN32_REGISTRY
+        None
+#else
         Option.ofString
             (try
                 downcast Microsoft.Win32.Registry.GetValue("HKEY_LOCAL_MACHINE\\"+subKey,null,null)
              with e->
                 System.Diagnostics.Debug.Assert(false, sprintf "Failed in GetDefaultRegistryStringValueViaDotNet: %s" (e.ToString()))
                 null)
+#endif
 
 // RegistryView.Registry API is not available before .NET 4.0
 #if FX_ATLEAST_40_COMPILER_LOCATION
@@ -185,7 +189,9 @@ module internal FSharpEnvironment =
             None
     
     let internal tryAppConfig (appConfigKey:string) = 
-
+#if NO_SYSTEM_CONFIG
+        None
+#else
         let locationFromAppConfig = ConfigurationSettings.AppSettings.[appConfigKey]
         System.Diagnostics.Debug.Print(sprintf "Considering appConfigKey %s which has value '%s'" appConfigKey locationFromAppConfig) 
 
@@ -196,6 +202,7 @@ module internal FSharpEnvironment =
             let locationFromAppConfig = locationFromAppConfig.Replace("{exepath}", exeAssemblyFolder)
             System.Diagnostics.Debug.Print(sprintf "Using path %s" locationFromAppConfig) 
             Some locationFromAppConfig
+#endif
 
     // The default location of FSharp.Core.dll and fsc.exe based on the version of fsc.exe that is running
     // Used for


### PR DESCRIPTION
**LIMITED_CONSOLE** to remove access to `Console.OutputEncoding/Color/BufferLength`
**NO_STRONGNAME_SIGNER** to remove strong name signing
**NO_NATIVE_RESOURCES** removes the linking of native resources, (this
never happens on mono anyway)
**NO_WIN32_REGISTRY** remove access to Microsoft.Win32.Registry
**NO_SYSTEM_CONFIG** removes access to System.Configuration

This allows component parts to be applied rather than the whole
**SILVERLIGHT** set of flags.  This is very useful for building FCS in
constrained environments like Andoid etc.
