### PR TITLE
Possible fix for #264

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 0.0.79 - 
+* Do not use memory mapped files when cracking a DLL to get an assembly reference
+* Fix for multilanguage projects in project cracker
+
 #### 0.0.78 - 
 * Reduce background checker memory usage
 * add docs on FSharp.Core

--- a/src/absil/ilread.fs
+++ b/src/absil/ilread.fs
@@ -3975,7 +3975,7 @@ let OpenILModuleReader infile opts =
           dispose = (fun () -> 
             mmap.Close();
             ClosePdbReader pdb) }
-    with :? System.DllNotFoundException ->
+    with _ ->
 #endif
         let mc = ByteFile.OpenIn infile
         let modul,ilAssemblyRefs,pdb = genOpenBinaryReader infile mc opts

--- a/src/fsharp/build.fs
+++ b/src/fsharp/build.fs
@@ -2447,7 +2447,7 @@ type AssemblyResolution =
                 | Some aref -> aref
                 | None -> 
                     let readerSettings : ILBinaryReader.ILReaderOptions = {pdbPath=None;ilGlobals = EcmaILGlobals;optimizeForMemory=false} // ??
-                    let reader = ILBinaryReader.OpenILModuleReader this.resolvedPath readerSettings
+                    let reader = ILBinaryReader.OpenILModuleReaderAfterReadingAllBytes this.resolvedPath readerSettings
                     try
                         mkRefToILAssembly reader.ILModuleDef.ManifestOfAssembly
                     finally 
@@ -2874,7 +2874,7 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
                     else 
                         try
                             let readerSettings : ILBinaryReader.ILReaderOptions = {pdbPath=None;ilGlobals = EcmaILGlobals;optimizeForMemory=false}
-                            let reader = ILBinaryReader.OpenILModuleReader resolved readerSettings
+                            let reader = ILBinaryReader.OpenILModuleReaderAfterReadingAllBytes resolved readerSettings
                             try
                                 let assRef = mkRefToILAssembly reader.ILModuleDef.ManifestOfAssembly
                                 assRef.QualifiedName


### PR DESCRIPTION
Fix for #264

This restricts two uses of memory mapped files and ensures that the ReadAllBytes fallback is used if memory mapping fails with some other exception besides DllNotFoundException.
