### PR TITLE
register FSharp.Core 4.3.0.0 in gac to fix FsSrGen

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 init:
   - git config --global core.autocrlf input
-  - "C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v8.1A\\bin\\NETFX 4.5.1 Tools\\x64\\gacutil.exe" /i "C:\\Program Files (x86)\\Reference Assemblies\\Microsoft\\FSharp\\.NETFramework\\v4.0\\4.3.0.0\\FSharp.Core.dll"
+  - '"C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v8.1A\\bin\\NETFX 4.5.1 Tools\\x64\\gacutil.exe" /i "C:\\Program Files (x86)\\Reference Assemblies\\Microsoft\\FSharp\\.NETFramework\\v4.0\\4.3.0.0\\FSharp.Core.dll"'
 build_script:
   - cmd: build.cmd Release
 test: off


### PR DESCRIPTION
Looks like `FsSrGen` has been failing the builds on AppVeyor for the last few days because it can't find FSharp.Core 4.3.0.0. I solved this on @jackfoxy's computer this morning too.

![image](https://cloud.githubusercontent.com/assets/80104/5175216/6819a2ee-73ed-11e4-9cde-3ab0681c3a84.png)
