### PR TITLE
Add FsDocsRepositoryBranch

### DIFF
--- a/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
+++ b/FSharp.Compiler.Service/FSharp.Compiler.Service.fsproj
@@ -34,6 +34,7 @@
     <FsDocsLogoLink>https://fsharp.org</FsDocsLogoLink>
     <FsDocsLicenseLink>https://github.com/dotnet/fsharp/blob/main/License.txt</FsDocsLicenseLink>
     <FsDocsReleaseNotesLink>https://github.com/dotnet/fsharp/blob/main/release-notes.md</FsDocsReleaseNotesLink>
+    <FsDocsRepositoryBranch>main</FsDocsRepositoryBranch>
     <RepositoryType>git</RepositoryType>
     <FsDocsWarnOnMissingDocs>true</FsDocsWarnOnMissingDocs>
   </PropertyGroup>


### PR DESCRIPTION
Currently, the FCS API docs link to the master branch when inspecting the source link.
I believe this setting will correct this, based on https://github.com/fsprojects/FSharp.Formatting/blob/b62fe97ebcf7aa815480b5a2a535859ac5f5e081/src/FSharp.Formatting.Common/Templating.fs#L92-92
I haven't tested this to be honest 😅.